### PR TITLE
Missing comma in 1-tuple

### DIFF
--- a/src/DataRead.jl
+++ b/src/DataRead.jl
@@ -137,7 +137,7 @@ function read_data_file(filename::String, filetype::Symbol)
             parser, bytestring(filename), pointer_from_objref(ctx))
     end
 
-    ccall( (:readstat_parser_free, "libreadstat"), Void, (Ptr{Void}), parser)
+    ccall( (:readstat_parser_free, "libreadstat"), Void, (Ptr{Void},), parser)
 
     if retval == 0
         return DataFrame(ctx.columns, ctx.colnames)


### PR DESCRIPTION
Fixes an error on Julia 0.3.7.

    julia> using DataRead
    ERROR: syntax: ccall argument types must be a tuple; try "(T,)"