### PR TITLE
Fix type error in DataReadValue

### DIFF
--- a/src/DataRead.jl
+++ b/src/DataRead.jl
@@ -34,7 +34,7 @@ immutable DataReadValue
     union::Int64
     readstat_types_t::Cint
     tag::Cchar
-    bits::UInt8
+    bits::Cuint
 end
 
 # actually not used


### PR DESCRIPTION
The type in the C code is unsigned int, sould be the same in the julia code. Without this, the tests don't pass on Windows.