### PR TITLE
Fix DataReadValue types

### DIFF
--- a/src/DataRead.jl
+++ b/src/DataRead.jl
@@ -34,7 +34,8 @@ immutable DataReadValue
     union::Int64
     readstat_types_t::Cint
     tag::Cchar
-    bits::Cuint
+    @windows_only bits::Cuint
+    @unix_only bits::Uint8
 end
 
 # actually not used


### PR DESCRIPTION
Apparently we need a different type on Unix and Win systems. I don't really understand it, but with this tests should pass on both systems (not yet CI testing, but that will come).