### PR TITLE
Wrap the error reporting function of ReadStat to provide more

### DIFF
--- a/src/ReadStat.jl
+++ b/src/ReadStat.jl
@@ -277,10 +277,14 @@ function Parser()
     return parser
 end
 
+function error_message(retval::Integer)
+    unsafe_string(ccall((:readstat_error_message, libreadstat), Ptr{Cchar}, (Cint,), retval))
+end
+
 function parse_data_file!(ds::ReadStatDataFrame, parser::Ptr{Nothing}, filename::AbstractString, filetype::Val)
     retval = readstat_parse(filename, filetype, parser, ds)
     readstat_parser_free(parser)
-    retval == 0 ||  error("Error parsing $filename: $retval")
+    retval == 0 ||  error("Error parsing $filename: $(error_message(retval))")
 end
 
 read_dta(filename::AbstractString) = read_data_file(filename, Val(:dta))


### PR DESCRIPTION
informative error messages.
```julia
julia> read_sas7bdat("brokenfile.sas7bdat")
ERROR: Error parsing brokenfile.sas7bdat: Unable to convert string to the requested encoding (invalid byte sequence)
Stacktrace:
 [1] error(s::String)
   @ Base ./error.jl:33
 [2] parse_data_file!(ds::ReadStatDataFrame, parser::Ptr{Nothing}, filename::String, filetype::Val{:sas7bdat})
   @ ReadStat ~/.julia/dev/ReadStat/src/ReadStat.jl:287
 [3] read_data_file(filename::String, filetype::Val{:sas7bdat})
   @ ReadStat ~/.julia/dev/ReadStat/src/ReadStat.jl:261
 [4] read_sas7bdat(filename::String)
   @ ReadStat ~/.julia/dev/ReadStat/src/ReadStat.jl:293
 [5] top-level scope
   @ REPL[5]:1
```
instead of just `ERROR: Error parsing brokenfile.sas7bdat: 17`